### PR TITLE
feat: add object locking boolean for buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Available variables are listed below along with default values (see `defaults\ma
   minio_server_addr: ""
   minio_console_port: "9092"
   ```
-  
+
   Minio admin user and password
   ```yml
   minio_root_user: ""
@@ -50,9 +50,9 @@ Available variables are listed below along with default values (see `defaults\ma
   ```yml
   minio_site_region: "eu-west-1"
   ```
-  
+
   Minio data directories (`minio_server_datadirs`) and whether force the creation in case they do not exist (`minio_server_make_datadirs`)
-  
+
   ```yml
   minio_server_make_datadirs: true
   minio_server_datadirs:
@@ -84,9 +84,9 @@ Available variables are listed below along with default values (see `defaults\ma
   ```
 
 - Minio client configuration
-  
+
   Connection alias name `minio_alias` and whether validate or not SSL certificates (`minio_validate_certificates`)
-  
+
   ```yml
   minio_validate_certificate: true
   minio_alias: "myminio"
@@ -114,21 +114,25 @@ Available variables are listed below along with default values (see `defaults\ma
 
 
 - Buckets to be created
-  
+
   Variable `minio_buckets` create the list of provided buckets, and applying a specifc policy. For creating the buckets, a modified version of Ansible Module from Alexis Facques is used (https://github.com/alexisfacques/ansible-module-s3-minio-bucket)
-  
+
   ```yml
   minio_buckets:
     - name: bucket1
       policy: read-only
     - name: bucket2
       policy: read-write
+      object_lock: false
     - name: bucket3
       policy: private
+      object_lock: true
   ```
   > NOTE The module use remote connection to Minio Server using Python API (`minio` python package). Role ensure that PIP is installed and install `minio` package.
 
   During bucket creation three types of policy can be specified: `private`, `read-only` or `read-write` buckets.
+
+  Minio object locking can also be enabled or disabled: `true` or `false`.
 
 - Users to be created and buckets ACLs
 
@@ -233,7 +237,7 @@ Available variables are listed below along with default values (see `defaults\ma
   minio_prometheus_bearer_token: false
   prometheus_bearer_token_output: "{{ minio_etc_dir }}/prometheus_bearer.json"
   ```
-  
+
   Setting `minio_prometheus_bearer_token` to true, generates a file `/etc/minio/prometheus_bearer.json` which contains the result of executing the command:
 
   `mc admin prometheus generate myminio -json`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ minio_buckets: []
 # minio_buckets:
 #  - name: bucket1
 #    policy: private
+#    object_lock: false
 
 minio_users: []
 # minio_users:

--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -53,8 +53,10 @@
               policy: read-write
             - name: bucket2
               policy: read-only
+              object_lock: true
             - name: bucket3
               policy: read-only
+              object_lock: false
             - name: bucket4
               policy: custom
               custom:

--- a/tasks/configure_server.yml
+++ b/tasks/configure_server.yml
@@ -15,15 +15,15 @@
   changed_when: false
   failed_when: '"Added `" + minio_alias + "` successfully" not in alias_command.stdout'
 
+- name: Create Minio Buckets
+  include_tasks: create_minio_buckets.yml
+
 - name: Create Minio Users
   include_tasks: create_minio_user.yml
   with_items:
     - "{{ minio_users }}"
   loop_control:
     loop_var: "user"
-
-- name: Create Minio Buckets
-  include_tasks: create_minio_buckets.yml
 
 # Create Prometheus bearer token
 - name: Create Prometheus bearer token

--- a/tasks/create_minio_buckets.yml
+++ b/tasks/create_minio_buckets.yml
@@ -26,6 +26,7 @@
     state: present
     policy: "{{ omit if bucket.policy == 'private' else bucket.policy }}"
     validate_certs: false
+    object_lock: "{{ bucket.object_lock | default(false) }}"
   with_items:
     - "{{ minio_buckets }}"
   loop_control:


### PR DESCRIPTION
Added `object_lock` value to bucket dicts to allow for creating buckets with minio object locking enabled since this has to be set at bucket creation:

https://min.io/docs/minio/container/administration/object-management/object-retention.html