### PR TITLE
Refresh apt cache in case apt is the package manager.

### DIFF
--- a/tasks/create_minio_buckets.yml
+++ b/tasks/create_minio_buckets.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Update apt cache if package manager is apt
+  apt:
+    update_cache: yes
+  when: ansible_facts['pkg_mgr'] == "apt"
+
 - name: Ensure PIP is installed.
   package:
     name:


### PR DESCRIPTION
Add a step of refreshing apt cache in case we are in a apt package managed system.