### PR TITLE
Use a virtual environment for minio_bucket.py

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,3 +81,6 @@ prometheus_bearer_token_output: "{{ minio_etc_dir }}/prometheus_bearer.json"
 
 # Environment variables to use when calling Pip
 minio_pip_environment_vars: {}
+
+# Path to minio virtual environment, created to avoid breakage with system managed python libraries
+minio_venv_path: "/opt/minio-venv"

--- a/library/minio_bucket.py
+++ b/library/minio_bucket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # coding: utf-8
 
 DOCUMENTATION = """

--- a/library/minio_bucket.py
+++ b/library/minio_bucket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8
 
 DOCUMENTATION = """

--- a/tasks/create_minio_buckets.yml
+++ b/tasks/create_minio_buckets.yml
@@ -30,8 +30,8 @@
     policy: "{{ omit if bucket.policy == 'private' else bucket.policy }}"
     validate_certs: false
     object_lock: "{{ bucket.object_lock | default(false) }}"
-  environment:
-    PATH: "{{ minio_venv_path }}/bin:$PATH"
+  vars:
+    ansible_python_interpreter: "{{ minio_venv_path }}/bin/python"
   with_items:
     - "{{ minio_buckets }}"
   loop_control:

--- a/tasks/create_minio_buckets.yml
+++ b/tasks/create_minio_buckets.yml
@@ -4,6 +4,7 @@
   package:
     name:
       - python3-pip
+      - python3-virtualenv
       - python3-setuptools
     state: present
 
@@ -13,6 +14,7 @@
       - minio
     state: present
     extra_args: --upgrade
+    virtualenv: "{{ minio_venv_path }}"
   environment: "{{ minio_pip_environment_vars }}"
   register: package_install
   until: package_install is succeeded
@@ -28,6 +30,8 @@
     policy: "{{ omit if bucket.policy == 'private' else bucket.policy }}"
     validate_certs: false
     object_lock: "{{ bucket.object_lock | default(false) }}"
+  environment:
+    PATH: "{{ minio_venv_path }}/bin:$PATH"
   with_items:
     - "{{ minio_buckets }}"
   loop_control:


### PR DESCRIPTION
Instead of messing around with the global system python installation we can just use a virtual environment to execute the miniio_bucket.py script.

- Added a new variable (minio_venv_path),
- changed the shebang in minio_bucket.py to make it accept our virtual environment,
- install a dependency for virtualenv,
- install pip dependencies to virtual environment,
- prepend virtual environment bin path to minio_bucket.py PATH to make it use the virtual environment

This is a bit hacky but since we will only be using this for minio_bucket.py invoked by Ansible I thought it was acceptable.  The virtual environment uses approx. 22 MB of storage on my server for this.