### PR TITLE
add support for bucket versioning

### DIFF
--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -32,6 +32,8 @@
       minio_url: "https://{{ server_hostname }}:{{ minio_server_port }}"
       minio_validate_certificate: false
       minio_prometheus_bearer_token: true
+      minio_pip_environment_vars:
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       minio_server_datadirs:
         - '/mnt/disk/minio'
       minio_server_cluster_nodes:
@@ -45,6 +47,12 @@
           policy: private
         - name: bucket4
           policy: private
+        - name: bucket5
+          policy: read-write
+          versioning: enabled
+        - name: bucket6
+          policy: read-write
+          versioning: suspended
       minio_users:
         - name: user1
           password: supers1cret0

--- a/molecule/site-replication/converge.yml
+++ b/molecule/site-replication/converge.yml
@@ -37,6 +37,12 @@
         - name: bucket3
           policy: private
           object_lock: true
+        - name: bucket5
+          policy: read-write
+          versioning: enabled
+        - name: bucket6
+          policy: read-write
+          versioning: suspended
       replication_sites:
         - name: minio1
           url: "http://minio1.ricsanfre.com:9091"

--- a/molecule/tls/converge.yml
+++ b/molecule/tls/converge.yml
@@ -28,8 +28,6 @@
       minio_url: "https://{{ server_hostname }}:9091"
       minio_validate_certificate: false
       minio_prometheus_bearer_token: true
-      minio_pip_environment_vars:
-        PIP_BREAK_SYSTEM_PACKAGES: "1"
       minio_buckets:
         - name: bucket1
           policy: read-write
@@ -37,7 +35,6 @@
           policy: read-only
         - name: bucket3
           policy: private
-          versioning: bar
         - name: bucket4
           policy: private
         - name: bucket5

--- a/molecule/tls/converge.yml
+++ b/molecule/tls/converge.yml
@@ -28,6 +28,8 @@
       minio_url: "https://{{ server_hostname }}:9091"
       minio_validate_certificate: false
       minio_prometheus_bearer_token: true
+      minio_pip_environment_vars:
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       minio_buckets:
         - name: bucket1
           policy: read-write
@@ -35,8 +37,15 @@
           policy: read-only
         - name: bucket3
           policy: private
+          versioning: bar
         - name: bucket4
           policy: private
+        - name: bucket5
+          policy: read-write
+          versioning: enabled
+        - name: bucket6
+          policy: read-write
+          versioning: suspended
       minio_users:
         - name: user1
           password: supers1cret0

--- a/tasks/create_minio_buckets.yml
+++ b/tasks/create_minio_buckets.yml
@@ -28,6 +28,7 @@
     secret_key: "{{ minio_root_password }}"
     state: present
     policy: "{{ omit if bucket.policy == 'private' else bucket.policy }}"
+    versioning: "{{ bucket.versioning | default(omit) }}"
     validate_certs: false
     object_lock: "{{ bucket.object_lock | default(false) }}"
   vars:


### PR DESCRIPTION
I have intentionally put "set_bucket_versioning" outside of "if not client.bucket_exists(bucket_name)" to be able to change existing buckets also. The question is if we want to do the same for policies?  

@ricsanfre, wanna review?