### PR TITLE
Allow use custom minio client binary name

### DIFF
--- a/tasks/configure_server.yml
+++ b/tasks/configure_server.yml
@@ -1,12 +1,12 @@
 ---
 - name: Set insecure mc command
   set_fact:
-    mc_command: "mc --insecure"
+    mc_command: "{{ minio_client_bin }} --insecure"
   when: not minio_validate_certificate
 
 - name: Set secure mc command
   set_fact:
-    mc_command: "mc"
+    mc_command: "{{ minio_client_bin }}"
   when: minio_validate_certificate
 
 - name: Configure minio connection alias


### PR DESCRIPTION
By default, the role assumes that minio client binary is `mc`, but it can conflict with Midnight Commander. I changed `set_fact` statements to allow use custom binary name. 