### PR TITLE
Do not pass certs dir when tls disabled

### DIFF
--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -8,7 +8,7 @@ MINIO_VOLUMES="{{ minio_server_datadirs | join(' ') }}"
 {% endif %}
 
 # Minio cli options.
-MINIO_OPTS="--address {{ minio_server_addr }}:{{ minio_server_port }} --console-address {{ minio_server_addr }}:{{ minio_console_port }} --certs-dir {{ minio_cert_dir }} {{ minio_server_opts }}"
+MINIO_OPTS="--address {{ minio_server_addr }}:{{ minio_server_port }} --console-address {{ minio_server_addr }}:{{ minio_console_port }} {% if minio_enable_tls %} --certs-dir {{ minio_cert_dir }} {% endif %} {{ minio_server_opts }}"
 
 {% if minio_root_user %}
 # Access Key of the server.


### PR DESCRIPTION
When TLS is disabled minio should not get a certs dir, otherwise it will only start with HTTPS.