### PR TITLE
Add write-only bucket policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Available variables are listed below along with default values (see `defaults\ma
   Users can be automatically created using  `minio_users` variable: a list of users can be provided, each user with three variables `name` (user name), `password` (user password) and `buckets_acl` list of buckets and type of access granted to each bucket (read-only or read-write).
   The role automatically create policy json files containing the user policy statements and load them into the server.
 
-  Predefined `read-only` and `read-write` policies, containing pre-defined access statements, can be used. Custom policies can be also defined using  `custom` policy. In this case list of access statements need to be provided.
+  Predefined `read-only`,`write-only` and `read-write` policies, containing pre-defined access statements, can be used. Custom policies can be also defined using  `custom` policy. In this case list of access statements need to be provided.
 
 
   ```yml

--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -49,6 +49,9 @@
           policy: read-write
           versioning: enabled
         - name: bucket6
+          policy: write-only
+          versioning: "enabled"
+        - name: bucket7
           policy: read-write
           versioning: suspended
       minio_users:

--- a/molecule/site-replication/converge.yml
+++ b/molecule/site-replication/converge.yml
@@ -41,6 +41,9 @@
           policy: read-write
           versioning: enabled
         - name: bucket6
+          policy: write-only
+          versioning: enabled
+        - name: bucket7
           policy: read-write
           versioning: suspended
       replication_sites:

--- a/molecule/tls/converge.yml
+++ b/molecule/tls/converge.yml
@@ -56,6 +56,10 @@
               policy: read-only
               object_lock: false
             - name: bucket4
+              policy: write-only
+              object_lock: false
+              versioning: "enabled"
+            - name: bucket5
               policy: custom
               custom:
                 - rule: |

--- a/templates/minio_policy.json.j2
+++ b/templates/minio_policy.json.j2
@@ -16,7 +16,7 @@
             "arn:aws:s3:::{{ acl['name'] }}",
             "arn:aws:s3:::{{ acl['name'] }}/*"
         ]
-    {{ "}," if not loop.last else "}" }}  
+    {{ "}," if not loop.last else "}" }}
 {% endif %}
 {% if acl['policy'] == 'read-only' %}
     {
@@ -31,11 +31,22 @@
         ]
     {{ "}," if not loop.last else "}" }}
 {% endif %}
+{% if acl['policy'] == 'write-only' %}
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:PutObject"
+        ],
+        "Resource": [
+            "arn:aws:s3:::{{ acl['name'] }}/*"
+        ]
+    {{ "}," if not loop.last else "}" }}
+{% endif %}
 {% if acl['policy'] == 'custom' and acl['custom'] %}
 {% for custom in acl.custom %}
     {
         {{ custom['rule'] }}
-    {{ "}," if not loop.last else "}" }}    
+    {{ "}," if not loop.last else "}" }}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
For some reason, the per-user bucket acl "write-only" policy was missed. This PR  slightly improves the deployment of the backup setup. The changes are trivial. Testing via Molecule is also slightly expanded.

In fact, for a full backup deployment, a Lifecycle Policy is also needed. But this can already be done with modules for S3