### PR TITLE
Adding support to install specific version of minio

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Available variables are listed below along with default values (see `defaults\ma
   ```
 - Minio server installation details
 
+  Minio release version to install
+
+  ```yml
+  minio_server_version: "RELEASE.2025-04-22T22-12-26Z"
+  minio_mc_version: "RELEASE.2025-04-16T18-13-26Z"
+  ```
+
   Minio UNIX user/group
   ```yml
   minio_group: minio
@@ -124,8 +131,8 @@ Available variables are listed below along with default values (see `defaults\ma
   > NOTE The module use remote connection to Minio Server using Python API (`minio` python package). Role ensure that PIP is installed and install `minio` package.
 
   During bucket creation three types of policy can be specified: `private`, `read-only` or `read-write` buckets.
-  >Reminder: The described configuration enables anonymous access by default.
-  >To restrict access by users, you need to specify a  `policy: private`
+  > Setting policy bucket to `read-only` or `read-write` enables anonymous access to the bucket (public bucket).
+  > To rekeep the bucket private and not enable annymous access `private` policy needs to be specified
 
 
   Minio object locking can also be enabled or disabled: `true` or `false`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,3 +84,7 @@ minio_pip_environment_vars: {}
 
 # Path to minio virtual environment, created to avoid breakage with system managed python libraries
 minio_venv_path: "/opt/minio-venv"
+
+# Version to install
+minio_server_version: "RELEASE.2025-04-22T22-12-26Z"
+minio_mc_version: "RELEASE.2025-04-16T18-13-26Z"

--- a/tasks/install_client.yml
+++ b/tasks/install_client.yml
@@ -2,7 +2,7 @@
 
 - name: Compose the Minio client download base url
   set_fact:
-    _minio_client_download_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch }}/mc"
+    _minio_client_download_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch }}/archive/mc.{{ minio_mc_version }}"
 
 - name: Get the Minio client checksum for architecture {{ go_arch }}
   set_fact:

--- a/tasks/install_server.yml
+++ b/tasks/install_server.yml
@@ -2,11 +2,12 @@
 
 - name: Compose the Minio server download url
   set_fact:
-    _minio_server_download_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch }}/minio"
+    _minio_server_download_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch }}/archive/minio.{{ minio_server_version }}"
 
 - name: Get the Minio server checksum for architecture {{ go_arch }}
   set_fact:
     _minio_server_checksum: "{{ lookup('url', _minio_server_download_url + '.sha256sum').split(' ')[0] }}"
+
 
 - name: Create Minio group
   group:


### PR DESCRIPTION
Add support to install any Minio version. With current implementation only latest available version can be installed

New variables `minio_server_version` and `minio_mc_version` to specify minio version to install.
