### PR TITLE
Allow external certificate management

### DIFF
--- a/tasks/install_server.yml
+++ b/tasks/install_server.yml
@@ -106,6 +106,7 @@
   service:
     name: minio
     enabled: true
+    state: started
 
 - name: Set secure minio url if not defined
   set_fact:

--- a/tasks/install_server.yml
+++ b/tasks/install_server.yml
@@ -83,9 +83,9 @@
     content: "{{ minio_key }}"
     owner: "{{ minio_user }}"
     group: "{{ minio_user }}"
-    mode: 0644
+    mode: 0640
   become: true
-  when: minio_enable_tls
+  when: minio_enable_tls and (minio_key | default("")) != ""
   notify: Restart minio
 
 - name: Copy cert file
@@ -94,9 +94,9 @@
     content: "{{ minio_cert }}"
     owner: "{{ minio_user }}"
     group: "{{ minio_user }}"
-    mode: 0644
+    mode: 0640
   become: true
-  when: minio_enable_tls
+  when: minio_enable_tls and (minio_cert | default("")) != ""
   notify: Restart minio
 
 - name: Flush handlers


### PR DESCRIPTION
I am using certbot to automatically deploy minio certs. Therefore, I adapted this role to:
- Only write certs if variable is not empty
- Limit access permission to certificates
- Also fix bug: Ensure minio server is started