### PR TITLE
Improved user creation

### DIFF
--- a/tasks/create_minio_user.yml
+++ b/tasks/create_minio_user.yml
@@ -29,7 +29,7 @@
   command: "{{ mc_command }} admin policy entities {{minio_alias }} --user {{ user.name }} --json"
   register: get_policies
   changed_when: false
-  failed_when: get_policies.rc != 0 or (get_policies.stdout | from_json)['status'] != "success" 
+  failed_when: get_policies.rc != 0 or (get_policies.stdout | from_json)['status'] != "success"
 
 - name: Extract policies
   set_fact:


### PR DESCRIPTION
- Idempotence: Fix issues with pre-existing users or policies.
  For example, when I deleted an user but not the policy file, the rule would not re-add the policy to the user after recreating the user.
- Use JSON output of `mc` instead of relying on the user interface. This solves an issue where the current matching does not mirror how newer `mc` outputs the messages.
- Remove wrong `failed` flag on the `Check whether user is already configured` task